### PR TITLE
x86 version of docker 1.10.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,19 @@
+sudo: required
+services:
+  - docker
+language: bash
+script:
+  - make binary
+  - sudo chown -R travis:travis bundles
+
+deploy:
+  provider: releases
+  api_key:
+    secure: "AG3zLxcYVjJotBPNDfYkHdO99w4R9GjHTK6elEQ1emGJPvdzua7S9Ro+07svwt0bClCQWnfFl0NCi7wthAnUGuU3TAjiTKpy5ErGxUFErmJMwl3cFVGR4Huk1cAd/aIwlxqb311+0a55xAIODnstXu3AULb0KTn39T70uIsDpzxNQ7jz340TIjkUiWZgPbTJTDxCnWljkcQVl45MgV7FIF96YJpf0escdgh2DkriyJePbMg2yWMH6l6/HSb3HOY8MVjufx6mJUSRWRY6VpJPxhzypEYsLaGaWbuTSYw4XmpFnfrAPK9tKMdPmvNySLME1IqoFCZgV2fu/Gl9WWVe6AuTkUUV5kosVxt6JJ8hvrGW7RGyoM4PuNrXB0E+ACDiRYzug4gBdng7rsC+yYO7ZHn5BwyaCozKXkzjWFLWeFJZyHrJ9X+MxpkBmtDbYEJiMIT2rW1eFER1RdtvaSzhAWhTk7JXNlCtHLPFaQhFmsTw1yvpnfswvVqLySDWJ4UM9SzP6zQHZ3pVV9EakVWnPAgOznnM8Q7fdHCTfL/5K8Wxi3/bgD0SUNgwEloNsFA3PZQLuttk1Q1Y/f3DiI1gQWmL0mkZzFizh2vt7NQAsiPyJCDc1PdNMV+ffJ2YGUVZ2lGg84iodKwaVsci3jg/ymrFWv5leuiUW0jOswaFfUs="
+  file:
+    - bundles/1.10.1/binary/docker-1.10.1
+  skip_cleanup: true
+  on:
+    tags: true
+    repo: StefanScherer/docker
+    all_branches: true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ be found.
 - Fix various issues with migration to content-addressable images [#20058](https://github.com/docker/docker/pull/20058)
 - Fix ZFS permission bug with user namespaces [#20045](https://github.com/docker/docker/pull/20045)
 - Do not leak /dev/mqueue from the host to all containers, keep it container-specific [#19876](https://github.com/docker/docker/pull/19876) [#20133](https://github.com/docker/docker/pull/20133)
-- Fix `docker ps --filter before=...` to work without needing `-a` flag [#20135](https://github.com/docker/docker/pull/20135)
+- Fix `docker ps --filter before=...` to not show stopped containers without providing `-a` flag [#20135](https://github.com/docker/docker/pull/20135)
 
 ### Security
 
@@ -27,7 +27,7 @@ be found.
 ### Networking
 
 - Fix embedded DNS for user-defined networks in the presence of firewalld [#20060](https://github.com/docker/docker/pull/20060)
-- Fix issue where removing a network during shutdown left Docker inoperable [#20181](https://github.com/docker/docker/issues/20181)
+- Fix issue where removing a network during shutdown left Docker inoperable [#20181](https://github.com/docker/docker/issues/20181) [#20235](https://github.com/docker/docker/issues/20235)
 - Embedded DNS is now able to return compressed results [#20181](https://github.com/docker/docker/issues/20181)
 - Fix port-mapping issue with `userland-proxy=false` [#20181](https://github.com/docker/docker/issues/20181)
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -23,7 +23,7 @@
 # the case. Therefore, you don't have to disable it anymore.
 #
 
-FROM ubuntu:trusty
+FROM 32bit/ubuntu:14.04
 
 # add zfs ppa
 RUN apt-key adv --keyserver hkp://p80.pool.sks-keyservers.net:80 --recv-keys E871F18B51E0147C77796AC81196BA81F6B0FC61
@@ -91,7 +91,7 @@ RUN cd /usr/local/lvm2 \
 #            will need updating, to avoid errors. Ping #docker-maintainers on IRC 
 #            with a heads-up.
 ENV GO_VERSION 1.5.3
-RUN curl -fsSL "https://storage.googleapis.com/golang/go${GO_VERSION}.linux-amd64.tar.gz" \
+RUN curl -fsSL "https://storage.googleapis.com/golang/go${GO_VERSION}.linux-386.tar.gz" \
 	| tar -xzC /usr/local
 ENV PATH /go/bin:/usr/local/go/bin:$PATH
 ENV GOPATH /go:/go/src/github.com/docker/docker/vendor
@@ -125,13 +125,13 @@ RUN git clone https://github.com/golang/lint.git /go/src/github.com/golang/lint 
 	&& go install -v github.com/golang/lint/golint
 
 # Configure the container for OSX cross compilation
-ENV OSX_SDK MacOSX10.11.sdk
-RUN set -x \
-	&& export OSXCROSS_PATH="/osxcross" \
-	&& git clone --depth 1 https://github.com/tpoechtrager/osxcross.git $OSXCROSS_PATH \
-	&& curl -sSL https://s3.dockerproject.org/darwin/${OSX_SDK}.tar.xz -o "${OSXCROSS_PATH}/tarballs/${OSX_SDK}.tar.xz" \
-	&& UNATTENDED=yes OSX_VERSION_MIN=10.6 ${OSXCROSS_PATH}/build.sh
-ENV PATH /osxcross/target/bin:$PATH
+#ENV OSX_SDK MacOSX10.11.sdk
+#RUN set -x \
+#	&& export OSXCROSS_PATH="/osxcross" \
+#	&& git clone --depth 1 https://github.com/tpoechtrager/osxcross.git $OSXCROSS_PATH \
+#	&& curl -sSL https://s3.dockerproject.org/darwin/${OSX_SDK}.tar.xz -o "${OSXCROSS_PATH}/tarballs/${OSX_SDK}.tar.xz" \
+#	&& UNATTENDED=yes OSX_VERSION_MIN=10.6 ${OSXCROSS_PATH}/build.sh
+#ENV PATH /osxcross/target/bin:$PATH
 
 # install seccomp
 # this can be changed to the ubuntu package libseccomp-dev if dockerinit is removed,
@@ -168,16 +168,16 @@ RUN set -x \
 	&& rm -rf "$GOPATH"
 
 # Install notary server
-ENV NOTARY_VERSION docker-v1.10-5
-RUN set -x \
-	&& export GOPATH="$(mktemp -d)" \
-	&& git clone https://github.com/docker/notary.git "$GOPATH/src/github.com/docker/notary" \
-	&& (cd "$GOPATH/src/github.com/docker/notary" && git checkout -q "$NOTARY_VERSION") \
-	&& GOPATH="$GOPATH/src/github.com/docker/notary/Godeps/_workspace:$GOPATH" \
-		go build -o /usr/local/bin/notary-server github.com/docker/notary/cmd/notary-server \
-	&& GOPATH="$GOPATH/src/github.com/docker/notary/Godeps/_workspace:$GOPATH" \
-		go build -o /usr/local/bin/notary github.com/docker/notary/cmd/notary \
-	&& rm -rf "$GOPATH"
+#ENV NOTARY_VERSION docker-v1.10-5
+#RUN set -x \
+#	&& export GOPATH="$(mktemp -d)" \
+#	&& git clone https://github.com/docker/notary.git "$GOPATH/src/github.com/docker/notary" \
+#	&& (cd "$GOPATH/src/github.com/docker/notary" && git checkout -q "$NOTARY_VERSION") \
+#	&& GOPATH="$GOPATH/src/github.com/docker/notary/Godeps/_workspace:$GOPATH" \
+#		go build -o /usr/local/bin/notary-server github.com/docker/notary/cmd/notary-server \
+#	&& GOPATH="$GOPATH/src/github.com/docker/notary/Godeps/_workspace:$GOPATH" \
+#		go build -o /usr/local/bin/notary github.com/docker/notary/cmd/notary \
+#	&& rm -rf "$GOPATH"
 
 # Get the "docker-py" source so we can run their integration tests
 ENV DOCKER_PY_COMMIT e2878cbcc3a7eef99917adc1be252800b0e41ece


### PR DESCRIPTION
Build the Docker Engine v1.10.1 for 32bit Intel x86 CPU's.

See also
-  https://github.com/StefanScherer/boot2docker/pull/1
- https://stefanscherer.github.io/how-to-create-a-32bit-boot2docker-for-x86-cpus/

The PR's just show the diffs, for an official PR there should be something like Dockerfile.i386...
